### PR TITLE
Upgrade Pocket ID to latest

### DIFF
--- a/.changes/unreleased/changed-20250930-234842.yaml
+++ b/.changes/unreleased/changed-20250930-234842.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade Pocket ID to v1.11.2
+time: 2025-09-30T23:48:42.247451+02:00

--- a/.changes/unreleased/changed-20250930-235037.yaml
+++ b/.changes/unreleased/changed-20250930-235037.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Swtich Pocket ID logging to WARN
+time: 2025-09-30T23:50:37.288689+02:00

--- a/.changes/unreleased/internal-20250930-233328.yaml
+++ b/.changes/unreleased/internal-20250930-233328.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: Use Bitnami legacy Minio image
+time: 2025-09-30T23:33:28.053166+02:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ ENV \
     KEYS_STORAGE=database \
     DB_CONNECTION_STRING=/app/data/pocket-id.db \
     UPLOAD_PATH=/app/data/uploads \
-    ANALYTICS_DISABLED=true
+    ANALYTICS_DISABLED=true \
+    LOG_LEVEL=warn
 
 EXPOSE 1411
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,18 +58,18 @@ RUN --mount=type=tmpfs,target=/tmp \
     mkdir -p /app; \
     cd /tmp; \
     { \
-        export POCKETID_VERSION=1.10.0; \
+        export POCKETID_VERSION=1.11.2; \
         case "$(arch)" in \
         x86_64) \
             export \
                 POCKETID_ARCH=amd64 \
-                POCKETID_SHA256=be00ac2358042294d80078ad19cb98528f9eefa6202fe35930f5ff81afd4293d \
+                POCKETID_SHA256=e314a86342e4d5a5397b48ad49f96939e20ac0f4f2f91473bffa95307dc95a66 \
             ; \
             ;; \
         aarch64) \
             export \
                 POCKETID_ARCH=arm64 \
-                POCKETID_SHA256=bc3aed53c123721f8c493337c50024f0dba16ac5a66acaa9cbd7bb022d84f79a \
+                POCKETID_SHA256=baffe36ec494d46a12bf73268aa17df0f639d0cf76d6065cfbf67ba504430fd3 \
             ; \
             ;; \
         esac; \

--- a/docs/compose.yaml
+++ b/docs/compose.yaml
@@ -48,7 +48,7 @@ services:
       - pocketid:/app/data
 
   replica1: &replica
-    image: registry.docker.com/bitnami/minio:latest
+    image: registry.docker.com/bitnamilegacy/minio:latest
     environment:
       - MINIO_ROOT_USER=keyid
       - MINIO_ROOT_PASSWORD=secretkey
@@ -60,12 +60,12 @@ services:
       timeout: 10s
       retries: 3
     volumes:
-      - replica1:/bitnami/minio/data
+      - replica1:/bitnamilegacy/minio/data
 
   replica2:
     <<: *replica
     volumes:
-      - replica2:/bitnami/minio/data
+      - replica2:/bitnamilegacy/minio/data
 
 volumes:
   pocketid:


### PR DESCRIPTION
The upgrade brings the latest bug fixes and improvements from Pocket ID v1.11.2. Setting the log level to WARN helps reduce unnecessary log output during normal operation, making it easier to spot actual issues.

I've also upgraded the Bitnami MinIO image being used in `docs` due recent deprecations, but not sure how long that will continue to work 🤷 